### PR TITLE
Support swiftself and swifterror for WebAssembly

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -640,6 +640,9 @@ bool WebAssemblyFastISel::fastLowerArguments() {
   if (F->isVarArg())
     return false;
 
+  if (FuncInfo.Fn->getCallingConv() == CallingConv::Swift)
+    return false;
+
   unsigned I = 0;
   for (auto const &Arg : F->args()) {
     const AttributeList &Attrs = F->getAttributes();
@@ -752,6 +755,9 @@ bool WebAssemblyFastISel::selectCall(const Instruction *I) {
 
   Function *Func = Call->getCalledFunction();
   if (Func && Func->isIntrinsic())
+    return false;
+
+  if (Call->getCallingConv() == CallingConv::Swift)
     return false;
 
   bool IsDirect = Func != nullptr;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFixFunctionBitcasts.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFixFunctionBitcasts.cpp
@@ -244,6 +244,10 @@ bool FixFunctionBitcasts::runOnModule(Module &M) {
 
   // Collect all the places that need wrappers.
   for (Function &F : M) {
+    // Skip to fix when the function is swiftcc because swiftcc allows
+    // bitcast type difference for swiftself and swifterror.
+    if (F.getCallingConv() == CallingConv::Swift)
+      continue;
     findUses(&F, F, Uses, ConstantBCs);
 
     // If we have a "main" function, and its type isn't

--- a/llvm/test/CodeGen/WebAssembly/swiftcc.ll
+++ b/llvm/test/CodeGen/WebAssembly/swiftcc.ll
@@ -1,0 +1,23 @@
+; RUN: llc < %s -asm-verbose=false | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown"
+
+; Test indirect function call between mismatched signatures
+; CHECK-LABEL: foo:
+; CHECK-NEXT: .functype       foo (i32, i32, i32, i32) -> ()
+define swiftcc void @foo(i32, i32) {
+  ret void
+}
+@data = global i8* bitcast (void (i32, i32)* @foo to i8*)
+
+; CHECK-LABEL: bar:
+; CHECK-NEXT: .functype       bar (i32, i32) -> ()
+; CHECK: call_indirect   (i32, i32, i32, i32) -> ()
+define swiftcc void @bar() {
+  %1 = load i8*, i8** @data
+  %2 = bitcast i8* %1 to void (i32, i32, i32)*
+  call swiftcc void %2(i32 1, i32 2, i32 swiftself 3)
+  ret void
+}
+


### PR DESCRIPTION
This patch is also sent to llvm-project upstream
https://reviews.llvm.org/D76049

## Overview
Support signature difference for swiftself and swifterror when cc is
swiftcc.

e.g.
```llvm
declare swiftcc void @foo(i32, i32)
@data = global i8* bitcast (void (i32, i32)* @foo to i8*)
define swiftcc void @bar() {
  %1 = load i8*, i8** @data
  %2 = bitcast i8* %1 to void (i32, i32, i32)*
  call swiftcc void %2(i32 1, i32 2, i32 swiftself 3)
  ret void
}
```

For swiftcc, emit additional swiftself and swifterror parameters
if there aren't while lowering. These additional parameters are added
for both callee and caller.
They are necessary to match callee and caller signature for indirect call.