### PR TITLE
[WASM] Put __clangast in custom section instead of data segment

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1856,6 +1856,9 @@ MCSection *TargetLoweringObjectFileWasm::getExplicitSectionGlobal(
   if (Name == ".llvmcmd" || Name == ".llvmbc")
     Kind = SectionKind::getMetadata();
 
+  if (Name == "__clangast")
+    Kind = SectionKind::getMetadata();
+
   StringRef Group = "";
   if (const Comdat *C = getWasmComdat(GO)) {
     Group = C->getName();


### PR DESCRIPTION
This patch was already applied before but I think it was lost while resolving conflicts. So apply again.

This patch resolves the https://github.com/swiftwasm/swift/pull/1582#issuecomment-688375879 issue